### PR TITLE
fix: switch back to deploy-ecs GitHub action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,13 +25,14 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - uses: mbta/actions/deploy-scheduled-ecs@v2
+      - uses: mbta/actions/deploy-ecs@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: linux-${{ inputs.environment == 'prod' && 'prod' || 'staging' }}
           ecs-service: uncooked-gps-${{ inputs.environment || 'dev' }}
           ecs-task-definition: uncooked-gps-${{ inputs.environment || 'dev' }}
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          launch-type: EXTERNAL
       - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
Asana Task: [Restore "See on Map" button and functionality](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210057497375325)

[[Error without this PR]](https://github.com/mbta/uncooked-gps/actions/runs/15595727569/job/43925595574#step:4:163)

I forgot to change the root MBTA GitHub action I'm using as a part of switching this to being serverful from an ephemeral task. Adding @krisrjohnson21 since we talked about it 👍 